### PR TITLE
Add BQN and APL grade up and grade down

### DIFF
--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -668,3 +668,7 @@
 | Common Lisp |            `min`             |   38   |           `-`           |       |                                                      [doc](https://novaspec.org/cl/f_max)                                                      |
 |    CUDA     |        `min_element`         |   38   |        `Thrust`         |       |                [doc](https://nvidia.github.io/cccl/thrust/api/function_group__extrema_1ga70a05eafeff24c0553adcbb51d8f052a.html)                |
 |    Ruby     |            `to_s`            |   16   |           `-`           |       |                                                   [doc](https://apidock.com/ruby/Object/to_s)                                                  |
+|     BQN     |      `⍒ (grade down)`       |   39   |           `-`           |       |                                      [doc](https://mlochbaum.github.io/BQN/help/gradedown_binsdown.html#-%F0%9D%95%A9-grade-down)             |
+|     BQN     |      `⍋ (grade up)`       |   40   |           `-`           |       |                                      [doc](https://mlochbaum.github.io/BQN/help/gradeup_binsup.html#-%F0%9D%95%A9-grade-up)             |
+|     APL     |      `⍋ (grade up)`       |   40   |           `-`           |       |                                      [doc](https://microapl.com/apl_help/ch_020_020_630.htm)             |
+|     APL     |      `⍒ (grade down)`       |   39   |           `-`           |       |                                      [doc](https://microapl.com/apl_help/ch_020_020_640.htm)             |


### PR DESCRIPTION
I've added the monadic `⍒` and `⍋` (grade down and grade up respectively) for both APL and BQN